### PR TITLE
changed the User class Entity cause there's a mismatch between your d…

### DIFF
--- a/src/main/java/com/flower/shop/cphpetalstudio/entity/User.java
+++ b/src/main/java/com/flower/shop/cphpetalstudio/entity/User.java
@@ -26,11 +26,16 @@ public class User {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "is_company", nullable = false)
+    private boolean isCompany;
+
+
+
     // Constructor
     public User() {
         this.createdAt = LocalDateTime.now();
+        this.isCompany = false; // Default value
     }
-
     // Getters and setters
 
     public Long getId() {


### PR DESCRIPTION
…atabase schema and your User entity. Specifically, there's a field called 'is_company' in your database table that doesn't have a default value, but it's not being set when creating a new user. Let's fix this by updating your User entity and ensuring the database schema matches.